### PR TITLE
Extract test names from AST

### DIFF
--- a/tasty-th.cabal
+++ b/tasty-th.cabal
@@ -14,7 +14,7 @@ author: Oscar Finnsson & Emil Nordling & Benno Fünfstück
 
 library
   exposed-modules: Test.Tasty.TH
-  build-depends: base >= 4 && < 5, tasty, template-haskell
+  build-depends: base >= 4 && < 5, haskell-src-exts >= 1.18.0, tasty, template-haskell
   hs-source-dirs: src
   other-extensions: TemplateHaskell
 


### PR DESCRIPTION
This is a fairly trivial change that makes tasty-th use haskell-src-exts to parse the file instead of simply looking at the first lexem in each line.

I don’t really have any experience with cabal, so, hopefully, I didn’t do anything wrong when adding the dependency.